### PR TITLE
Add faraday middleware

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,3 +11,7 @@ Metrics/LineLength:
   Max: 140
   Exclude:
     - '**/*_spec.rb'
+
+Metrics/MethodLength:
+  Exclude:
+    - 'lib/faraday/http/signatures/signature_signer.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@ AllCops:
   TargetRubyVersion: 1.9
   Exclude:
     - '**/config.ru'
+    - 'vendor/**/*'
 
 Style/Documentation:
   Enabled: false

--- a/faraday-http-signatures.gemspec
+++ b/faraday-http-signatures.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake', '~> 10.0'
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rubocop', '~> 0.39.0'
-  s.add_runtime_dependency 'rack', '>= 1.5'
-  s.add_runtime_dependency 'faraday', '>= 0.9.2'
+  s.add_runtime_dependency 'rack', '~> 1.5'
+  s.add_runtime_dependency 'faraday', '~> 0.9'
 end

--- a/faraday-http-signatures.gemspec
+++ b/faraday-http-signatures.gemspec
@@ -22,6 +22,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake', '~> 10.0'
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rubocop', '~> 0.39.0'
-  s.add_runtime_dependency 'rack', '~> 1.5'
   s.add_runtime_dependency 'faraday', '~> 0.9'
 end

--- a/lib/faraday/http/signatures.rb
+++ b/lib/faraday/http/signatures.rb
@@ -2,6 +2,10 @@ module Faraday
   module Http
     module Signatures
       require 'faraday/http/signatures/version'
+      require 'faraday/http/signatures/signature'
+
+      Faraday::Request.register_middleware \
+        http_signatures: -> { Signature }
     end
   end
 end

--- a/lib/faraday/http/signatures/config.rb
+++ b/lib/faraday/http/signatures/config.rb
@@ -23,7 +23,7 @@ module Faraday
           end
         end
 
-        options_accessor :digest_header, :digest_algorithm, :signature_header, :signature_algorithm
+        options_accessor :signature_header, :signature_algorithm, :digest_algorithm, :digest_header, :headers
 
         private
 
@@ -31,7 +31,8 @@ module Faraday
           { signature_algorithm: 'RSA-SHA256',
             signature_header:    'Authorization',
             digest_algorithm:    'SHA-256',
-            digest_header:       'Digest'
+            digest_header:       'Digest',
+            headers:             'All headers'
           }
         end
       end

--- a/lib/faraday/http/signatures/config.rb
+++ b/lib/faraday/http/signatures/config.rb
@@ -1,0 +1,40 @@
+module Faraday
+  module Http
+    module Signatures
+      class Config
+        attr_reader :key_id, :private_key
+
+        def initialize(key_id, private_key, options = {})
+          @key_id      = key_id
+          @private_key = private_key
+          @options     = default_options.merge(options)
+        end
+
+        def self.options_accessor(*names) #:nodoc:
+          names.each do |name|
+            class_eval <<-METHOD, __FILE__, __LINE__ + 1
+          def #{name}
+            @options[:#{name}]
+          end
+          def #{name}=(value)
+            @options[:#{name}] = value
+          end
+            METHOD
+          end
+        end
+
+        options_accessor :digest_header, :digest_algorithm, :signature_header, :signature_algorithm
+
+        private
+
+        def default_options
+          { signature_algorithm: 'RSA-SHA256',
+            signature_header:    'Authorization',
+            digest_algorithm:    'SHA-256',
+            digest_header:       'Digest'
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/faraday/http/signatures/digest_cipher_factory.rb
+++ b/lib/faraday/http/signatures/digest_cipher_factory.rb
@@ -1,0 +1,23 @@
+require 'faraday/http/signatures/digest_ciphers/sha256'
+
+module Faraday
+  module Http
+    module Signatures
+      class DigestCipherFactory
+        UnknownAlgorithmError = Class.new(ArgumentError)
+        VALID_ALGORITHMS      = %w(sha-256).freeze
+
+        class << self
+          def create(algorithm)
+            case algorithm.downcase
+            when 'sha-256' then
+              DigestCiphers::SHA256
+            else
+              raise UnknownAlgorithmError, 'Unknown Digest algorithm'
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/faraday/http/signatures/digest_ciphers/sha256.rb
+++ b/lib/faraday/http/signatures/digest_ciphers/sha256.rb
@@ -1,0 +1,21 @@
+require 'openssl'
+
+module Faraday
+  module Http
+    module Signatures
+      module DigestCiphers
+        module SHA256
+          class << self
+            SHA256 = OpenSSL::Digest::SHA256.new
+
+            def encrypt(message)
+              SHA256.reset
+              SHA256 << message
+              SHA256.digest
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/faraday/http/signatures/digest_ciphers/sha256.rb
+++ b/lib/faraday/http/signatures/digest_ciphers/sha256.rb
@@ -6,12 +6,10 @@ module Faraday
       module DigestCiphers
         module SHA256
           class << self
-            SHA256 = OpenSSL::Digest::SHA256.new
-
             def encrypt(message)
-              SHA256.reset
-              SHA256 << message
-              SHA256.digest
+              sha256 = OpenSSL::Digest::SHA256.new
+              sha256 << message
+              sha256.digest
             end
           end
         end

--- a/lib/faraday/http/signatures/digest_signer.rb
+++ b/lib/faraday/http/signatures/digest_signer.rb
@@ -1,5 +1,4 @@
 require 'faraday/http/signatures/digest_cipher_factory'
-require 'faraday/http/signatures/signer'
 require 'base64'
 
 module Faraday

--- a/lib/faraday/http/signatures/digest_signer.rb
+++ b/lib/faraday/http/signatures/digest_signer.rb
@@ -1,0 +1,35 @@
+require 'faraday/http/signatures/digest_cipher_factory'
+require 'base64'
+
+module Faraday
+  module Http
+    module Signatures
+      class DigestSigner
+        def initialize(digest_header, algorithm, env)
+          @digest_header = digest_header
+          @algorithm     = algorithm
+          @env           = env.dup
+        end
+
+        def signed_env
+          @env[:request_headers][@digest_header] = "#{@algorithm}=#{digest_base64}"
+          @env
+        end
+
+        private
+
+        def digest_base64
+          @digest_base64 ||= Base64.strict_encode64(digest)
+        end
+
+        def digest
+          @digest ||= DigestCipherFactory.create(@algorithm).encrypt(body)
+        end
+
+        def body
+          @env[:body] || ''
+        end
+      end
+    end
+  end
+end

--- a/lib/faraday/http/signatures/digest_signer.rb
+++ b/lib/faraday/http/signatures/digest_signer.rb
@@ -1,4 +1,5 @@
 require 'faraday/http/signatures/digest_cipher_factory'
+require 'faraday/http/signatures/signer'
 require 'base64'
 
 module Faraday
@@ -6,13 +7,13 @@ module Faraday
     module Signatures
       class DigestSigner
         def initialize(digest_header, algorithm, env)
-          @digest_header = digest_header
-          @algorithm     = algorithm
-          @env           = env.dup
+          @signature_header = digest_header
+          @algorithm        = algorithm
+          @env              = env.dup
         end
 
         def signed_env
-          @env[:request_headers][@digest_header] = "#{@algorithm}=#{digest_base64}"
+          @env[:request_headers][@signature_header] = "#{@algorithm}=#{digest_base64}"
           @env
         end
 

--- a/lib/faraday/http/signatures/signature.rb
+++ b/lib/faraday/http/signatures/signature.rb
@@ -1,6 +1,7 @@
 require 'faraday'
 require 'faraday/http/signatures/config'
 require 'faraday/http/signatures/digest_signer'
+require 'faraday/http/signatures/signature_signer'
 
 module Faraday
   module Http
@@ -13,6 +14,7 @@ module Faraday
 
         def call(env)
           signed_env = digest_signer(env).signed_env
+          signed_env = signature_signer(signed_env).signed_env
           @app.call(signed_env)
         end
 
@@ -20,6 +22,10 @@ module Faraday
 
         def digest_signer(env)
           DigestSigner.new(@config.digest_header, @config.digest_algorithm, env)
+        end
+
+        def signature_signer(env)
+          SignatureSigner.new(@config, env)
         end
       end
     end

--- a/lib/faraday/http/signatures/signature.rb
+++ b/lib/faraday/http/signatures/signature.rb
@@ -1,0 +1,27 @@
+require 'faraday'
+require 'faraday/http/signatures/config'
+require 'faraday/http/signatures/digest_signer'
+
+module Faraday
+  module Http
+    module Signatures
+      class Signature < Faraday::Middleware
+        def initialize(app, key_id, private_key, options = {})
+          super(app)
+          @config = Faraday::Http::Signatures::Config.new(key_id, private_key, options)
+        end
+
+        def call(env)
+          signed_env = digest_signer(env).signed_env
+          @app.call(signed_env)
+        end
+
+        private
+
+        def digest_signer(env)
+          DigestSigner.new(@config.digest_header, @config.digest_algorithm, env)
+        end
+      end
+    end
+  end
+end

--- a/lib/faraday/http/signatures/signature_cipher_factory.rb
+++ b/lib/faraday/http/signatures/signature_cipher_factory.rb
@@ -1,0 +1,26 @@
+require 'faraday/http/signatures/signature_ciphers/hs256'
+require 'faraday/http/signatures/signature_ciphers/rsa256'
+
+module Faraday
+  module Http
+    module Signatures
+      class SignatureCipherFactory
+        UnknownAlgorithmError = Class.new(ArgumentError)
+        VALID_ALGORITHMS      = %w(rsa-sha256 hmac-sha256).freeze
+
+        class << self
+          def create(algorithm)
+            case algorithm.downcase
+            when 'rsa-sha256' then
+              SignatureCiphers::RSA256
+            when 'hmac-sha256' then
+              SignatureCiphers::HS256
+            else
+              raise UnknownAlgorithmError, 'Unknown Signature algorithm'
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/faraday/http/signatures/signature_ciphers/hs256.rb
+++ b/lib/faraday/http/signatures/signature_ciphers/hs256.rb
@@ -1,0 +1,19 @@
+require 'openssl'
+
+module Faraday
+  module Http
+    module Signatures
+      module SignatureCiphers
+        class HS256
+          class << self
+            DIGEST = OpenSSL::Digest::SHA256.new
+
+            def encrypt(key, data)
+              OpenSSL::HMAC.hexdigest(DIGEST, key, data)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/faraday/http/signatures/signature_ciphers/rsa256.rb
+++ b/lib/faraday/http/signatures/signature_ciphers/rsa256.rb
@@ -9,8 +9,8 @@ module Faraday
             DIGEST = OpenSSL::Digest::SHA256.new
 
             def encrypt(key, data)
-              private = OpenSSL::PKey::RSA.new(key)
-              private.sign(DIGEST, data)
+              private_key = OpenSSL::PKey::RSA.new(key)
+              private_key.sign(DIGEST, data)
             end
           end
         end

--- a/lib/faraday/http/signatures/signature_ciphers/rsa256.rb
+++ b/lib/faraday/http/signatures/signature_ciphers/rsa256.rb
@@ -1,0 +1,20 @@
+require 'openssl'
+
+module Faraday
+  module Http
+    module Signatures
+      module SignatureCiphers
+        class RSA256
+          class << self
+            DIGEST = OpenSSL::Digest::SHA256.new
+
+            def encrypt(key, data)
+              private = OpenSSL::PKey::RSA.new(key)
+              private.sign(DIGEST, data)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/faraday/http/signatures/signature_signer.rb
+++ b/lib/faraday/http/signatures/signature_signer.rb
@@ -1,0 +1,72 @@
+require 'faraday/http/signatures/signature_cipher_factory'
+require 'base64'
+
+module Faraday
+  module Http
+    module Signatures
+      class SignatureSigner
+        def initialize(config, env)
+          @env              = env.dup
+          @key_id           = config.key_id
+          @private_key      = config.private_key
+          @headers          = config.headers == 'All headers' ? all_headers : config.headers.split(' ')
+          @signature_header = config.signature_header
+          @algorithm        = config.signature_algorithm
+        end
+
+        def signed_env
+          @env[:request_headers][@signature_header] = authorization_header_value
+          @env
+        end
+
+        private
+
+        def signature_base64
+          @signature_base64 ||= Base64.strict_encode64(signature)
+        end
+
+        def signature
+          @signature ||= SignatureCipherFactory.create(@algorithm).encrypt(@private_key, signed_data)
+        end
+
+        def signed_data
+          @signed_data ||= @headers.map do |header|
+            case header.downcase
+            when '(request-target)' then
+              "#{header}: #{@env[:method]} #{relative_url}"
+            when 'host' then
+              "#{header}: #{@env[:url].hostname}"
+            when 'content-length' then
+              "#{header}: #{body.size}"
+            else
+              raise ArgumentError, "header '#{header}' not found" unless @env[:request_headers].key?(header)
+              "#{header}: #{@env[:request_headers][header]}"
+            end
+          end.join("\n")
+        end
+
+        def authorization_header_value
+          'Signature ' \
+            "keyId=\"#{@key_id}\"," \
+            "algorithm=\"#{@algorithm.downcase}\"," \
+            "headers=\"#{@headers.join(' ')}\"," \
+            "signature=\"#{signature_base64}\""
+        end
+
+        def relative_url
+          "#{@env[:url].request_uri}#{"##{@env[:url].fragment}" if @env[:url].fragment}"
+        end
+
+        def all_headers
+          header_list = %w((request-target) host)
+          @env[:request_headers].each { |header, _value| header_list << header.downcase }
+          header_list << 'content-length' unless body.empty?
+        end
+
+        def body
+          @env[:body] || ''
+        end
+      end
+    end
+  end
+end

--- a/spec/faraday/http/signatures/digest_cipher_factory_spec.rb
+++ b/spec/faraday/http/signatures/digest_cipher_factory_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe Faraday::Http::Signatures::DigestCipherFactory do
+  { 'sha-256' => Faraday::Http::Signatures::DigestCiphers::SHA256 }.each do |algorithm, klass|
+    it "returns #{algorithm}" do
+      expect(described_class.create(algorithm)).to eq(klass)
+    end
+  end
+
+  it 'raises UnknownAlgorithmError' do
+    expect { described_class.create('unknown-algorithm') }.to raise_error(described_class::UnknownAlgorithmError, 'Unknown Digest algorithm')
+  end
+end

--- a/spec/faraday/http/signatures/digest_ciphers/sha256_spec.rb
+++ b/spec/faraday/http/signatures/digest_ciphers/sha256_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+require 'base64'
+
+describe Faraday::Http::Signatures::DigestCiphers::SHA256 do
+  it 'encrypts the message' do
+    expect(Base64.strict_encode64(described_class.encrypt('{"hello": "world"}'))).to eq('X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=')
+  end
+end

--- a/spec/faraday/http/signatures/signature_ciphers/hs256_spec.rb
+++ b/spec/faraday/http/signatures/signature_ciphers/hs256_spec.rb
@@ -1,0 +1,11 @@
+require 'openssl'
+
+describe Faraday::Http::Signatures::SignatureCiphers::HS256 do
+  let(:private_key) { File.read('spec/support/fixtures/hs256/key.txt') }
+  let(:valid_signature) { 'NzU4ZDAyMGRmNzQxZmQ3NDQ0YWY0Mzk5Y2YxMjUzYzA1NGI2MWQ2OTc5NjhlYjM3NTg2Y2I1MmFiMDlkN2NkNA==' }
+  let(:message) { 'date: Thu, 05 Jan 2014 21:31:40 GMT' }
+
+  it 'encrypts the message' do
+    expect(Base64.strict_encode64(described_class.encrypt(private_key, message))).to eq(valid_signature)
+  end
+end

--- a/spec/faraday/http/signatures/signature_ciphers/rsa256_spec.rb
+++ b/spec/faraday/http/signatures/signature_ciphers/rsa256_spec.rb
@@ -1,0 +1,11 @@
+require 'openssl'
+
+describe Faraday::Http::Signatures::SignatureCiphers::RSA256 do
+  let(:private_key) { File.read('spec/support/fixtures/rsa256/private.pem') }
+  let(:valid_signature) { 'jKyvPcxB4JbmYY4mByyBY7cZfNl4OW9HpFQlG7N4YcJPteKTu4MWCLyk+gIr0wDgqtLWf9NLpMAMimdfsH7FSWGfbMFSrsVTHNTk0rK3usrfFnti1dxsM4jl0kYJCKTGI/UWkqiaxwNiKqGcdlEDrTcUhhsFsOIo8VhddmZTZ8w=' }
+  let(:message) { 'date: Thu, 05 Jan 2014 21:31:40 GMT' }
+
+  it 'encrypts the message' do
+    expect(Base64.strict_encode64(described_class.encrypt(private_key, message))).to eq(valid_signature)
+  end
+end

--- a/spec/faraday/http/signatures/signature_spec.rb
+++ b/spec/faraday/http/signatures/signature_spec.rb
@@ -2,40 +2,108 @@ require 'spec_helper'
 require 'pp'
 
 describe Faraday::Http::Signatures::Signature do
-  let(:options) { {} }
-  let(:conn) do
-    Faraday.new do |builder|
-      builder.request :http_signatures, 'Test', File.read('spec/support/fixtures/rsa256/private.pem'), options
-      builder.adapter :test, Faraday::Adapter::Test::Stubs.new do |stub|
-        stub.post('/digest') { |env| [200, env[:request_headers], env[:body]] }
-      end
-    end
+  let(:options) { { headers: '(request-target) host date content-type digest content-length' } }
+  let(:body) { '{"hello": "world"}' }
+
+  let(:request_headers) do
+    { 'Date'         => 'Thu, 05 Jan 2014 21:31:40 GMT',
+      'Content-Type' => 'application/json'
+    }
   end
 
-  context 'digest header' do
-    let(:body) { '{"hello": "world"}' }
+  context 'create digest' do
     let(:digest) { 'X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=' }
 
-    context 'valid algorithm' do
+    context 'with valid algorithm' do
       it 'creates digest from body' do
-        response = conn.post('/digest') { |request| request.body = body }
+        response = send_request(body)
         expect(response.headers['Digest']).to eq("SHA-256=#{digest}")
       end
 
       it 'creates digest with empty body' do
-        response = conn.post('/digest') { |request| request.body = nil }
+        response = send_request(nil)
         expect(response.headers['Digest']).to eq('SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=')
       end
     end
 
     context 'invalid algorithm' do
-      let(:options) do
-        { digest_algorithm: 'unknown algorithm' }
-      end
+      let(:options) { { digest_algorithm: 'unknown algorithm' } }
 
       it 'raise error' do
         unknown_algorithm = Faraday::Http::Signatures::DigestCipherFactory::UnknownAlgorithmError
-        expect { conn.post('/digest') }.to raise_error(unknown_algorithm, 'Unknown Digest algorithm')
+        expect { send_request(body) }.to raise_error(unknown_algorithm, 'Unknown Digest algorithm')
+      end
+    end
+  end
+
+  context 'create signature' do
+    context 'from header list with custom header name' do
+      context 'rsa-sha256 (default)' do
+        let(:options) do
+          { headers:          '(request-target) host date content-type digest content-length',
+            signature_header: 'Auth'
+          }
+        end
+
+        it 'creates signature' do
+          response = send_request(body)
+          expect(response.headers['Auth']).to eq('Signature keyId="Test",algorithm="rsa-sha256",headers="(request-target) host date content-type digest content-length",signature="Ef7MlxLXoBovhil3AlyjtBwAL9g4TN3tibLj7uuNB3CROat/9KaeQ4hW2NiJ+pZ6HQEOx9vYZAyi+7cmIkmJszJCut5kQLAwuX+Ms/mUFvpKlSo9StS2bMXDBNjOh4Auj774GFj4gwjS+3NhFeoqyr/MuN6HsEnkvn6zdgfE2i0="')
+        end
+      end
+
+      context 'hmac-sha256' do
+        let(:options) do
+          { headers:             '(request-target) host date content-type digest content-length',
+            signature_header:    'Auth',
+            signature_algorithm: 'hmac-sha256'
+          }
+        end
+
+        it 'creates signature with hmac-sha256' do
+          conn     = connection('spec/support/fixtures/hs256/key.txt')
+          response = send_request(body, conn)
+          expect(response.headers['Auth']).to eq('Signature keyId="Test",algorithm="hmac-sha256",headers="(request-target) host date content-type digest content-length",signature="M2Q2ODg4ZDU4ZjAxODgyNWJlMjY1ZmI3YTg2NWM2Nzc1ZDA5MzhiMWRkOTk3MzJkMGZmMWVjY2U0YmNmNDFiMA=="')
+        end
+      end
+
+      context 'invalid algorithm' do
+        let(:options) do
+          { headers:             '(request-target) host date content-type digest content-length',
+            signature_algorithm: 'invalid algorithm'
+          }
+        end
+
+        it 'raises unknown algorithm error' do
+          unknown_algorithm = Faraday::Http::Signatures::SignatureCipherFactory::UnknownAlgorithmError
+          expect { send_request(body) }.to raise_error(unknown_algorithm, 'Unknown Signature algorithm')
+        end
+      end
+    end
+
+    context 'from all headers' do
+      let(:options) { { headers: 'All headers' } }
+
+      it 'creates signature by default (all http headers)' do
+        response = send_request(body)
+        expect(response.headers['Authorization']).to eq('Signature keyId="Test",algorithm="rsa-sha256",headers="(request-target) host user-agent date content-type digest content-length",signature="W6pRJE1tyY6hIuksffqMjA3HNwIIQC+8n3OXDThaAV9ZrWlkaIKHoIG24LQKpHd7axx7D0pzPA4nUX171aw32QdxLWx67K5aFSnsI9SPiYvU0DgGCUg5VrELQI9d9dZo69iaqxAfBTsQkm6uxHs0hv/Sdu4A84oYE27BT2NDoh4="')
+      end
+    end
+  end
+
+  def send_request(body, conn = nil)
+    conn = connection unless conn
+    conn.post('http://example.com/foo?param=value&pet=dog') do |request|
+      request[:date]         = request_headers['Date']
+      request[:content_type] = request_headers['Content-Type']
+      request.body           = body
+    end
+  end
+
+  def connection(key_path = 'spec/support/fixtures/rsa256/private.pem')
+    Faraday.new do |builder|
+      builder.request :http_signatures, 'Test', File.read(key_path), options
+      builder.adapter :test, Faraday::Adapter::Test::Stubs.new do |stub|
+        stub.post('http://example.com/foo?param=value&pet=dog') { |env| [200, env[:request_headers], env[:body]] }
       end
     end
   end

--- a/spec/faraday/http/signatures/signature_spec.rb
+++ b/spec/faraday/http/signatures/signature_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+require 'pp'
+
+describe Faraday::Http::Signatures::Signature do
+  let(:options) { {} }
+  let(:conn) do
+    Faraday.new do |builder|
+      builder.request :http_signatures, 'Test', File.read('spec/support/fixtures/rsa256/private.pem'), options
+      builder.adapter :test, Faraday::Adapter::Test::Stubs.new do |stub|
+        stub.post('/digest') { |env| [200, env[:request_headers], env[:body]] }
+      end
+    end
+  end
+
+  context 'digest header' do
+    let(:body) { '{"hello": "world"}' }
+    let(:digest) { 'X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=' }
+
+    context 'valid algorithm' do
+      it 'creates digest from body' do
+        response = conn.post('/digest') { |request| request.body = body }
+        expect(response.headers['Digest']).to eq("SHA-256=#{digest}")
+      end
+
+      it 'creates digest with empty body' do
+        response = conn.post('/digest') { |request| request.body = nil }
+        expect(response.headers['Digest']).to eq('SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=')
+      end
+    end
+
+    context 'invalid algorithm' do
+      let(:options) do
+        { digest_algorithm: 'unknown algorithm' }
+      end
+
+      it 'raise error' do
+        unknown_algorithm = Faraday::Http::Signatures::DigestCipherFactory::UnknownAlgorithmError
+        expect { conn.post('/digest') }.to raise_error(unknown_algorithm, 'Unknown Digest algorithm')
+      end
+    end
+  end
+end

--- a/spec/faraday/http/signatures/singature_cipher_factory_spec.rb
+++ b/spec/faraday/http/signatures/singature_cipher_factory_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe Faraday::Http::Signatures::SignatureCipherFactory do
+  { 'hmac-sha256' => Faraday::Http::Signatures::SignatureCiphers::HS256,
+    'rsa-sha256'  => Faraday::Http::Signatures::SignatureCiphers::RSA256
+  }.each do |algorithm, klass|
+    it "returns #{algorithm}" do
+      expect(described_class.create(algorithm)).to eq(klass)
+    end
+  end
+
+  it 'raises UnknownAlgorithmError' do
+    expect { described_class.create('unknown-algorithm') }.to raise_error(described_class::UnknownAlgorithmError, 'Unknown Signature algorithm')
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,3 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+require 'faraday'
 require 'faraday/http/signatures'


### PR DESCRIPTION
Middleware add digest and signature

Sample usage:
```ruby
require 'faraday'
require 'faraday/http/signatures'
require 'pp'

conn = Faraday.new(url: 'http://localhost:9292') do |faraday|
  faraday.request :http_signatures, 'Test', File.read('spec/support/fixtures/rsa256/private.pem')
  faraday.adapter Faraday.default_adapter
end

response = conn.post('/') do |r|
  r.body = '{"hello": "world"}'
end
pp response
```